### PR TITLE
Upgrade numpy and fft-correlation dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
           workspaces: native-helper
 
       - name: Install release build dependencies
-        run: python -m pip install --upgrade pip numpy maturin
+        run: python -m pip install --upgrade pip 'numpy>=2,<3' maturin
 
       - name: Build wheel
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
           workspaces: native-helper
 
       - name: Install release build dependencies
-        run: python -m pip install --upgrade pip 'numpy>=2,<3' maturin
+        run: python -m pip install --upgrade pip 'numpy>=2.0,<3' maturin
 
       - name: Build wheel
         env:

--- a/audio_pattern_detector/audio_utils.py
+++ b/audio_pattern_detector/audio_utils.py
@@ -3,7 +3,7 @@ import subprocess
 import sys
 from collections.abc import Generator
 from contextlib import contextmanager
-from typing import IO, Any
+from typing import IO, Any, TypeVar
 
 import numpy as np
 from numpy.typing import NDArray
@@ -171,7 +171,10 @@ def resample_audio(audio: NDArray[np.float32], orig_sr: int, target_sr: int) -> 
     return resample(audio, num_samples)
 
 
-def slicing_with_zero_padding(array: NDArray[np.floating[Any]], width: int, middle_index: int) -> NDArray[np.floating[Any]]:
+_FloatT = TypeVar("_FloatT", bound=np.floating[Any])
+
+
+def slicing_with_zero_padding(array: NDArray[_FloatT], width: int, middle_index: int) -> NDArray[_FloatT]:
     padding = width / 2
 
     beg = int(middle_index - math.floor(padding))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "audio-pattern-detector"
-version = "0.3.19"
+version = "0.3.20"
 description = ""
 authors = [{ name = "Andrew Chen", email = "hello@andrewtheguy.com" }]
 requires-python = "~=3.12.0"
 readme = "README.md"
 dependencies = [
     "fft-correlation==0.0.4",
-    "numpy>=1.26.4,<2",
+    "numpy>=2.0,<3",
     "andrew-utils",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [{ name = "Andrew Chen", email = "hello@andrewtheguy.com" }]
 requires-python = "~=3.12.0"
 readme = "README.md"
 dependencies = [
-    "fft-correlation==0.0.4",
+    "fft-correlation==0.0.5",
     "numpy>=2.0,<3",
     "andrew-utils",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ source = { git = "https://github.com/andrewtheguy/andrew_utils.git?tag=0.1.2#1e9
 
 [[package]]
 name = "audio-pattern-detector"
-version = "0.3.19"
+version = "0.3.20"
 source = { editable = "." }
 dependencies = [
     { name = "andrew-utils" },
@@ -36,7 +36,7 @@ dev = [
 requires-dist = [
     { name = "andrew-utils", git = "https://github.com/andrewtheguy/andrew_utils.git?tag=0.1.2" },
     { name = "fft-correlation", specifier = "==0.0.4", index = "https://andrewtheguy.github.io/fft-correlation/simple/" },
-    { name = "numpy", specifier = ">=1.26.4,<2" },
+    { name = "numpy", specifier = ">=2.0,<3" },
 ]
 
 [package.metadata.requires-dev]
@@ -211,18 +211,21 @@ wheels = [
 
 [[package]]
 name = "numpy"
-version = "1.26.4"
+version = "2.4.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010", size = 15786129, upload-time = "2024-02-06T00:26:44.495Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/12/8f2020a8e8b8383ac0177dc9570aad031a3beb12e38847f7129bacd96228/numpy-1.26.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b3ce300f3644fb06443ee2222c2201dd3a89ea6040541412b8fa189341847218", size = 20335901, upload-time = "2024-02-05T23:55:32.801Z" },
-    { url = "https://files.pythonhosted.org/packages/75/5b/ca6c8bd14007e5ca171c7c03102d17b4f4e0ceb53957e8c44343a9546dcc/numpy-1.26.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:03a8c78d01d9781b28a6989f6fa1bb2c4f2d51201cf99d3dd875df6fbd96b23b", size = 13685868, upload-time = "2024-02-05T23:55:56.28Z" },
-    { url = "https://files.pythonhosted.org/packages/79/f8/97f10e6755e2a7d027ca783f63044d5b1bc1ae7acb12afe6a9b4286eac17/numpy-1.26.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9fad7dcb1aac3c7f0584a5a8133e3a43eeb2fe127f47e3632d43d677c66c102b", size = 13925109, upload-time = "2024-02-05T23:56:20.368Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/50/de23fde84e45f5c4fda2488c759b69990fd4512387a8632860f3ac9cd225/numpy-1.26.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:675d61ffbfa78604709862923189bad94014bef562cc35cf61d3a07bba02a7ed", size = 17950613, upload-time = "2024-02-05T23:56:56.054Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/0c/9c603826b6465e82591e05ca230dfc13376da512b25ccd0894709b054ed0/numpy-1.26.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab47dbe5cc8210f55aa58e4805fe224dac469cde56b9f731a4c098b91917159a", size = 13572172, upload-time = "2024-02-05T23:57:21.56Z" },
-    { url = "https://files.pythonhosted.org/packages/76/8c/2ba3902e1a0fc1c74962ea9bb33a534bb05984ad7ff9515bf8d07527cadd/numpy-1.26.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1dda2e7b4ec9dd512f84935c5f126c8bd8b9f2fc001e9f54af255e8c5f16b0e0", size = 17786643, upload-time = "2024-02-05T23:57:56.585Z" },
-    { url = "https://files.pythonhosted.org/packages/28/4a/46d9e65106879492374999e76eb85f87b15328e06bd1550668f79f7b18c6/numpy-1.26.4-cp312-cp312-win32.whl", hash = "sha256:50193e430acfc1346175fcbdaa28ffec49947a06918b7b92130744e81e640110", size = 5677803, upload-time = "2024-02-05T23:58:08.963Z" },
-    { url = "https://files.pythonhosted.org/packages/16/2e/86f24451c2d530c88daf997cb8d6ac622c1d40d19f5a031ed68a4b73a374/numpy-1.26.4-cp312-cp312-win_amd64.whl", hash = "sha256:08beddf13648eb95f8d867350f6a018a4be2e5ad54c8d8caed89ebca558b2818", size = 15517754, upload-time = "2024-02-05T23:58:36.364Z" },
+    { url = "https://files.pythonhosted.org/packages/28/05/32396bec30fb2263770ee910142f49c1476d08e8ad41abf8403806b520ce/numpy-2.4.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:15716cfef24d3a9762e3acdf87e27f58dc823d1348f765bbea6bef8c639bfa1b", size = 16689272, upload-time = "2026-03-29T13:18:49.223Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/f3/a983d28637bfcd763a9c7aafdb6d5c0ebf3d487d1e1459ffdb57e2f01117/numpy-2.4.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:23cbfd4c17357c81021f21540da84ee282b9c8fba38a03b7b9d09ba6b951421e", size = 14699573, upload-time = "2026-03-29T13:18:52.629Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/fd/e5ecca1e78c05106d98028114f5c00d3eddb41207686b2b7de3e477b0e22/numpy-2.4.4-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:8b3b60bb7cba2c8c81837661c488637eee696f59a877788a396d33150c35d842", size = 5204782, upload-time = "2026-03-29T13:18:55.579Z" },
+    { url = "https://files.pythonhosted.org/packages/de/2f/702a4594413c1a8632092beae8aba00f1d67947389369b3777aed783fdca/numpy-2.4.4-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:e4a010c27ff6f210ff4c6ef34394cd61470d01014439b192ec22552ee867f2a8", size = 6552038, upload-time = "2026-03-29T13:18:57.769Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/37/eed308a8f56cba4d1fdf467a4fc67ef4ff4bf1c888f5fc980481890104b1/numpy-2.4.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f9e75681b59ddaa5e659898085ae0eaea229d054f2ac0c7e563a62205a700121", size = 15670666, upload-time = "2026-03-29T13:19:00.341Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/0d/0e3ecece05b7a7e87ab9fb587855548da437a061326fff64a223b6dcb78a/numpy-2.4.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:81f4a14bee47aec54f883e0cad2d73986640c1590eb9bfaaba7ad17394481e6e", size = 16645480, upload-time = "2026-03-29T13:19:03.63Z" },
+    { url = "https://files.pythonhosted.org/packages/34/49/f2312c154b82a286758ee2f1743336d50651f8b5195db18cdb63675ff649/numpy-2.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:62d6b0f03b694173f9fcb1fb317f7222fd0b0b103e784c6549f5e53a27718c44", size = 17020036, upload-time = "2026-03-29T13:19:07.428Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/e9/736d17bd77f1b0ec4f9901aaec129c00d59f5d84d5e79bba540ef12c2330/numpy-2.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fbc356aae7adf9e6336d336b9c8111d390a05df88f1805573ebb0807bd06fd1d", size = 18368643, upload-time = "2026-03-29T13:19:10.775Z" },
+    { url = "https://files.pythonhosted.org/packages/63/f6/d417977c5f519b17c8a5c3bc9e8304b0908b0e21136fe43bf628a1343914/numpy-2.4.4-cp312-cp312-win32.whl", hash = "sha256:0d35aea54ad1d420c812bfa0385c71cd7cc5bcf7c65fed95fc2cd02fe8c79827", size = 5961117, upload-time = "2026-03-29T13:19:13.464Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/5b/e1deebf88ff431b01b7406ca3583ab2bbb90972bbe1c568732e49c844f7e/numpy-2.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:b5f0362dc928a6ecd9db58868fca5e48485205e3855957bdedea308f8672ea4a", size = 12320584, upload-time = "2026-03-29T13:19:16.155Z" },
+    { url = "https://files.pythonhosted.org/packages/58/89/e4e856ac82a68c3ed64486a544977d0e7bdd18b8da75b78a577ca31c4395/numpy-2.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:846300f379b5b12cc769334464656bc882e0735d27d9726568bc932fdc49d5ec", size = 10221450, upload-time = "2026-03-29T13:19:18.994Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -35,7 +35,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "andrew-utils", git = "https://github.com/andrewtheguy/andrew_utils.git?tag=0.1.2" },
-    { name = "fft-correlation", specifier = "==0.0.4", index = "https://andrewtheguy.github.io/fft-correlation/simple/" },
+    { name = "fft-correlation", specifier = "==0.0.5", index = "https://andrewtheguy.github.io/fft-correlation/simple/" },
     { name = "numpy", specifier = ">=2.0,<3" },
 ]
 
@@ -108,16 +108,16 @@ wheels = [
 
 [[package]]
 name = "fft-correlation"
-version = "0.0.4"
+version = "0.0.5"
 source = { registry = "https://andrewtheguy.github.io/fft-correlation/simple/" }
 dependencies = [
     { name = "numpy" },
 ]
 wheels = [
-    { url = "https://github.com/andrewtheguy/fft-correlation/releases/download/v0.0.4/fft_correlation-0.0.4-cp39-abi3-macosx_11_0_arm64.whl" },
-    { url = "https://github.com/andrewtheguy/fft-correlation/releases/download/v0.0.4/fft_correlation-0.0.4-cp39-abi3-manylinux_2_34_aarch64.whl" },
-    { url = "https://github.com/andrewtheguy/fft-correlation/releases/download/v0.0.4/fft_correlation-0.0.4-cp39-abi3-manylinux_2_34_x86_64.whl" },
-    { url = "https://github.com/andrewtheguy/fft-correlation/releases/download/v0.0.4/fft_correlation-0.0.4-cp39-abi3-win_amd64.whl" },
+    { url = "https://github.com/andrewtheguy/fft-correlation/releases/download/v0.0.5/fft_correlation-0.0.5-cp39-abi3-macosx_11_0_arm64.whl" },
+    { url = "https://github.com/andrewtheguy/fft-correlation/releases/download/v0.0.5/fft_correlation-0.0.5-cp39-abi3-manylinux_2_34_aarch64.whl" },
+    { url = "https://github.com/andrewtheguy/fft-correlation/releases/download/v0.0.5/fft_correlation-0.0.5-cp39-abi3-manylinux_2_34_x86_64.whl" },
+    { url = "https://github.com/andrewtheguy/fft-correlation/releases/download/v0.0.5/fft_correlation-0.0.5-cp39-abi3-win_amd64.whl" },
 ]
 
 [[package]]


### PR DESCRIPTION
Update numpy to version 2.0 and fft-correlation to version 0.0.5. Adjust project version to 0.3.20 and update related dependency constraints in the workflow.